### PR TITLE
[Fix LGTM]: Remove conflicted WAP_GUI patch

### DIFF
--- a/debian/patches/series
+++ b/debian/patches/series
@@ -2,7 +2,6 @@
 02_dbus_group_policy.patch
 06_wpa_gui_menu_exec_path.patch
 07_dbus_service_syslog.patch
-12_wpa_gui_knotify_support.patch
 networkd-driver-fallback.patch
 wpa_supplicant_fix-dependency-odering-when-invoked-with-dbus.patch
 allow-tlsv1.patch

--- a/lgtm.yml
+++ b/lgtm.yml
@@ -12,14 +12,26 @@ extraction:
       - libpcsclite-dev
       - docbook-to-man
       - docbook-utils
-      - libnl-genl-3-dev
+      - libxml-simple-perl
+      - qtbase5-dev
+      - aspell
+      - aspell-en
+      - libhiredis-dev
       - libnl-3-dev
+      - libnl-genl-3-dev
       - libnl-route-3-dev
+      - libnl-nf-3-dev
+      - swig3.0
+      - libpython2.7-dev
+      - libgtest-dev
+      - dh-exec
+      - libzmq3-dev
+      - libzmq5
     after_prepare:
       - ls -l
       - git clone https://github.com/Azure/sonic-swss-common; pushd sonic-swss-common; ./autogen.sh; fakeroot dpkg-buildpackage -us -uc -b; popd
       - dpkg-deb -x libswsscommon_1.0.0_amd64.deb $LGTM_WORKSPACE
       - dpkg-deb -x libswsscommon-dev_1.0.0_amd64.deb $LGTM_WORKSPACE
-    configure:
-      command:
-      - pushd wpa_supplicant; cp defconfig .config; make; popd
+    index:
+      build_command:
+      - dpkg-buildpackage -rfakeroot -b -us -uc


### PR DESCRIPTION
Remove a patch for WPA_GUI in debian and add dependencies in lgtm.yml
This patch is for hostap_2_9, but it's not compatible with the master branch.

Signed-off-by: Ze Gan <ganze718@gmail.com>