### PR TITLE
Fix missing refactor

### DIFF
--- a/src/drivers/driver_macsec_sonic.c
+++ b/src/drivers/driver_macsec_sonic.c
@@ -453,7 +453,7 @@ static int macsec_sonic_set_transmit_next_pn(void *priv, struct transmit_sa *sa)
     char * buffer = create_buffer("%" PRIu64 "", sa->next_pn);
     const struct sonic_db_name_value_pair pairs[] = 
     {
-        {"init_pn", buffer}
+        {"next_pn", buffer}
     };
     int ret = sonic_db_set(
         drv->sonic_manager,


### PR DESCRIPTION
It's clearer to rename the init_pn to next_pn.

We have a commit(https://github.com/Azure/sonic-wpa-supplicant/commit/e77db616ff9d7675d354b29791aa6b6e21227c11) to rename all init_pn to next_pn. But it forgot to modify the name in `macsec_sonic_set_transmit_next_pn`. This PR is for fixing this mistake.
