### PR TITLE
Fixbug: wrong SA key

### DIFF
--- a/src/drivers/driver_macsec_sonic.c
+++ b/src/drivers/driver_macsec_sonic.c
@@ -70,7 +70,7 @@ static char * create_buffer(const char * fmt, ...)
 #define CREATE_SA_KEY(IFNAME, SA, SEPARATOR)    \
     create_buffer(                              \
         "%s"                                    \
-        SEPARATOR "%" PRIu64 "",                \
+        SEPARATOR "%" PRIu64 ""                 \
         SEPARATOR "%u",                         \
         IFNAME,                                 \
         mka_sci_u64(&SA->sc->sci),              \


### PR DESCRIPTION
This PR is for fixing the wrong key of SA.

There is a wrong comma in `CREATE_SA_KEY` which cuts the format string. The expected key of SA should like `Ethernet0:72203427286897918:0`, but the wrong format will cause that it like `::%u:72203427286897918:0`

Signed-off-by: Ze Gan <ganze718@gmail.com>