### PR TITLE
Fix for CP state machine issues

### DIFF
--- a/src/pae/ieee802_1x_cp.c
+++ b/src/pae/ieee802_1x_cp.c
@@ -393,9 +393,9 @@ SM_STEP(CP)
 	case CP_RECEIVING:
 		if (sm->new_sak || changed_connect(sm))
 			SM_ENTER(CP, ABANDON);
-		if (!sm->elected_self)
+		else if (!sm->elected_self)
 			SM_ENTER(CP, READY);
-		if (sm->elected_self &&
+		else if (sm->elected_self &&
 		    (sm->all_receiving || !sm->controlled_port_enabled ||
 		     !sm->transmit_when))
 			SM_ENTER(CP, TRANSMIT);
@@ -421,7 +421,7 @@ SM_STEP(CP)
 	case CP_READY:
 		if (sm->new_sak || changed_connect(sm))
 			SM_ENTER(CP, ABANDON);
-		if (sm->server_transmitting || !sm->controlled_port_enabled)
+		else if (sm->server_transmitting || !sm->controlled_port_enabled)
 			SM_ENTER(CP, TRANSMIT);
 		break;
 	case CP_ABANDON:


### PR DESCRIPTION
This PR is to fix issues with CP state machine found during testing AN rollover.
It was seen that when MACsec live peer timeout coincides with AN rollover on Key server, there can be two valid state machine transitions from CP Receiving state:  Abandon and Transmit.  This results in both Abandon and Transmit handling being executed by CP state machine, Key server will remain stuck in invalid Transmit state, and CP state machine will not recover without manual intervention.
Changes update CP state machine so that multiple transition paths cannot be executed from any given CP state.