### PR TITLE
[macsec_sonic] driver support for macsec_include_sci

### DIFF
--- a/src/drivers/driver_macsec_sonic.c
+++ b/src/drivers/driver_macsec_sonic.c
@@ -156,6 +156,7 @@ static int macsec_sonic_macsec_init(void *priv, struct macsec_init_params *param
     {
         {"enable", "false"},
         {"cipher_suite" , "GCM-AES-128"}, // Default cipher suite
+        {"send_sci", params->always_include_sci ? "true" : "false"},
     };
     int ret = sonic_db_set(
         drv->sonic_manager,


### PR DESCRIPTION
**What I did**
Support was previously added for "macsec_include_sci" attribute in wpasupplicant configuration profile, but this support was not extended to macsec_sonic driver and SONiC APPL_DB.  I have added the needed support in the macsec_sonic driver to allow the "send_sci" APPL_DB attribute to be configured by "macsec_include_sci" wpasupplicant attribute.

**Why I did it**
Missing support in wpasupplicant macsec_sonic driver for send_sci APPL_DB attribute.

**How I verified it**
System test with VS and JNPR platforms.

**Details if related**
N/A