### PR TITLE
Proactively rekey

### DIFF
--- a/src/ap/wpa_auth_kay.c
+++ b/src/ap/wpa_auth_kay.c
@@ -328,6 +328,7 @@ int ieee802_1x_alloc_kay_sm_hapd(struct hostapd_data *hapd,
 	res = ieee802_1x_kay_init(kay_ctx, policy, 0, 0, 1,
 				  hapd->conf->macsec_replay_protect,
 				  hapd->conf->macsec_replay_window,
+				  0,
 				  hapd->conf->macsec_port,
 				  hapd->conf->mka_priority, hapd->conf->iface,
 				  hapd->own_addr);

--- a/src/pae/ieee802_1x_kay.c
+++ b/src/pae/ieee802_1x_kay.c
@@ -1398,6 +1398,13 @@ ieee802_1x_mka_encode_sak_use_body(
 				participant->new_sak = true;
 			}
 		}
+		if (kay->macsec_rekey_period != 0 && kay->dist_time != 0) {
+			if ((kay->dist_time + kay->macsec_rekey_period) < time(NULL)) {
+				participant->new_sak = true;
+				wpa_printf(MSG_WARNING,
+					"KaY: Rekey period");
+			}
+		}
 	}
 
 	/* plain tx, plain rx */
@@ -3558,6 +3565,7 @@ ieee802_1x_kay_init(struct ieee802_1x_kay_ctx *ctx, enum macsec_policy policy,
 		    int macsec_ciphersuite, enum confidentiality_offset macsec_offset,
 		    bool macsec_include_sci,
 		    bool macsec_replay_protect, u32 macsec_replay_window,
+		    int macsec_rekey_period,
 		    u16 port, u8 priority, const char *ifname, const u8 *addr)
 {
 	struct ieee802_1x_kay *kay;
@@ -3599,6 +3607,8 @@ ieee802_1x_kay_init(struct ieee802_1x_kay_ctx *ctx, enum macsec_policy policy,
 	kay->pn_exhaustion = cipher_suite_tbl[kay->macsec_csindex].pn_exhaustion;
 	kay->mka_algindex = DEFAULT_MKA_ALG_INDEX;
 	kay->mka_version = MKA_VERSION_ID;
+
+	kay->macsec_rekey_period = macsec_rekey_period;
 
 	os_memcpy(kay->algo_agility, mka_algo_agility,
 		  sizeof(kay->algo_agility));

--- a/src/pae/ieee802_1x_kay.c
+++ b/src/pae/ieee802_1x_kay.c
@@ -1398,8 +1398,8 @@ ieee802_1x_mka_encode_sak_use_body(
 				participant->new_sak = true;
 			}
 		}
-		if (kay->macsec_rekey_period != 0 && kay->dist_time != 0) {
-			if ((kay->dist_time + kay->macsec_rekey_period) < time(NULL)) {
+		if (kay->mka_rekey_period != 0 && kay->dist_time != 0) {
+			if ((kay->dist_time + kay->mka_rekey_period) < time(NULL)) {
 				participant->new_sak = true;
 				wpa_printf(MSG_WARNING,
 					"KaY: Rekey period");
@@ -3565,7 +3565,7 @@ ieee802_1x_kay_init(struct ieee802_1x_kay_ctx *ctx, enum macsec_policy policy,
 		    int macsec_ciphersuite, enum confidentiality_offset macsec_offset,
 		    bool macsec_include_sci,
 		    bool macsec_replay_protect, u32 macsec_replay_window,
-		    int macsec_rekey_period,
+		    int mka_rekey_period,
 		    u16 port, u8 priority, const char *ifname, const u8 *addr)
 {
 	struct ieee802_1x_kay *kay;
@@ -3608,7 +3608,7 @@ ieee802_1x_kay_init(struct ieee802_1x_kay_ctx *ctx, enum macsec_policy policy,
 	kay->mka_algindex = DEFAULT_MKA_ALG_INDEX;
 	kay->mka_version = MKA_VERSION_ID;
 
-	kay->macsec_rekey_period = macsec_rekey_period;
+	kay->mka_rekey_period = mka_rekey_period;
 
 	os_memcpy(kay->algo_agility, mka_algo_agility,
 		  sizeof(kay->algo_agility));

--- a/src/pae/ieee802_1x_kay.h
+++ b/src/pae/ieee802_1x_kay.h
@@ -222,6 +222,8 @@ struct ieee802_1x_kay {
 	u8 dist_an;
 	time_t dist_time;
 
+	int macsec_rekey_period;
+
 	u8 mka_version;
 	u8 algo_agility[4];
 
@@ -249,6 +251,7 @@ ieee802_1x_kay_init(struct ieee802_1x_kay_ctx *ctx, enum macsec_policy policy,
 		    int macsec_ciphersuite, enum confidentiality_offset macsec_offset,
 		    bool macsec_include_sci,
 		    bool macsec_replay_protect, u32 macsec_replay_window,
+		    int macsec_rekey_period,
 		    u16 port, u8 priority, const char *ifname, const u8 *addr);
 void ieee802_1x_kay_deinit(struct ieee802_1x_kay *kay);
 

--- a/src/pae/ieee802_1x_kay.h
+++ b/src/pae/ieee802_1x_kay.h
@@ -222,7 +222,7 @@ struct ieee802_1x_kay {
 	u8 dist_an;
 	time_t dist_time;
 
-	int macsec_rekey_period;
+	int mka_rekey_period;
 
 	u8 mka_version;
 	u8 algo_agility[4];
@@ -251,7 +251,7 @@ ieee802_1x_kay_init(struct ieee802_1x_kay_ctx *ctx, enum macsec_policy policy,
 		    int macsec_ciphersuite, enum confidentiality_offset macsec_offset,
 		    bool macsec_include_sci,
 		    bool macsec_replay_protect, u32 macsec_replay_window,
-		    int macsec_rekey_period,
+		    int mka_rekey_period,
 		    u16 port, u8 priority, const char *ifname, const u8 *addr);
 void ieee802_1x_kay_deinit(struct ieee802_1x_kay *kay);
 

--- a/wpa_supplicant/config.c
+++ b/wpa_supplicant/config.c
@@ -2555,7 +2555,7 @@ static const struct parse_data ssid_fields[] = {
 	{ INT_RANGE(macsec_policy, 0, 1) },
 	{ INT_RANGE(macsec_integ_only, 0, 1) },
 	{ INT_RANGE(macsec_ciphersuite, 0, 3) },
-	{ INT_RANGE(macsec_rekey_period, 0, INT_MAX) },
+	{ INT_RANGE(mka_rekey_period, 0, INT_MAX) },
 	{ INT_RANGE(macsec_conf_offset, 0, 3) },
 	{ INT_RANGE(macsec_include_sci, 0, 1) },
 	{ INT_RANGE(macsec_replay_protect, 0, 1) },

--- a/wpa_supplicant/config.c
+++ b/wpa_supplicant/config.c
@@ -20,6 +20,7 @@
 #include "fst/fst.h"
 #include "config.h"
 
+#include <limits.h>
 
 #if !defined(CONFIG_CTRL_IFACE) && defined(CONFIG_NO_CONFIG_WRITE)
 #define NO_CONFIG_WRITE
@@ -2554,6 +2555,7 @@ static const struct parse_data ssid_fields[] = {
 	{ INT_RANGE(macsec_policy, 0, 1) },
 	{ INT_RANGE(macsec_integ_only, 0, 1) },
 	{ INT_RANGE(macsec_ciphersuite, 0, 3) },
+	{ INT_RANGE(macsec_rekey_period, 0, INT_MAX) },
 	{ INT_RANGE(macsec_conf_offset, 0, 3) },
 	{ INT_RANGE(macsec_include_sci, 0, 1) },
 	{ INT_RANGE(macsec_replay_protect, 0, 1) },

--- a/wpa_supplicant/config_file.c
+++ b/wpa_supplicant/config_file.c
@@ -903,7 +903,7 @@ static void wpa_config_write_network(FILE *f, struct wpa_ssid *ssid)
 	write_mka_ckn(f, ssid);
 	INT(macsec_integ_only);
 	INT(macsec_ciphersuite);
-	INT_DEF(macsec_rekey_period, 0);
+	INT_DEF(mka_rekey_period, 0);
 	INT(macsec_conf_offset);
 	INT(macsec_include_sci);
 	INT(macsec_replay_protect);

--- a/wpa_supplicant/config_file.c
+++ b/wpa_supplicant/config_file.c
@@ -903,6 +903,7 @@ static void wpa_config_write_network(FILE *f, struct wpa_ssid *ssid)
 	write_mka_ckn(f, ssid);
 	INT(macsec_integ_only);
 	INT(macsec_ciphersuite);
+	INT_DEF(macsec_rekey_period, 0);
 	INT(macsec_conf_offset);
 	INT(macsec_include_sci);
 	INT(macsec_replay_protect);

--- a/wpa_supplicant/config_ssid.h
+++ b/wpa_supplicant/config_ssid.h
@@ -905,11 +905,11 @@ struct wpa_ssid {
 	int macsec_replay_protect;
 
 	/**
-	 * macsec_rekey_period - The period of proactively refresh(Unit second).
+	 * mka_rekey_period - The period of proactively refresh(Unit second).
 	 *
 	 * Default 0 which means never proactive refresh SAK
 	 */
-	int macsec_rekey_period;
+	int mka_rekey_period;
 
 	/**
 	 * macsec_replay_window - MACsec replay protection window

--- a/wpa_supplicant/config_ssid.h
+++ b/wpa_supplicant/config_ssid.h
@@ -905,6 +905,13 @@ struct wpa_ssid {
 	int macsec_replay_protect;
 
 	/**
+	 * macsec_rekey_period - The period of proactively refresh(Unit second).
+	 *
+	 * Default 0 which means never proactive refresh SAK
+	 */
+	int macsec_rekey_period;
+
+	/**
 	 * macsec_replay_window - MACsec replay protection window
 	 *
 	 * A window in which replay is tolerated, to allow receipt of frames

--- a/wpa_supplicant/wpa_cli.c
+++ b/wpa_supplicant/wpa_cli.c
@@ -1478,7 +1478,7 @@ static const char *network_fields[] = {
 	"macsec_policy",
 	"macsec_integ_only",
 	"macsec_ciphersuite",
-	"macsec_rekey_period",
+	"mka_rekey_period",
 	"macsec_conf_offset",
 	"macsec_include_sci",
 	"macsec_replay_protect",

--- a/wpa_supplicant/wpa_cli.c
+++ b/wpa_supplicant/wpa_cli.c
@@ -1478,6 +1478,7 @@ static const char *network_fields[] = {
 	"macsec_policy",
 	"macsec_integ_only",
 	"macsec_ciphersuite",
+	"macsec_rekey_period",
 	"macsec_conf_offset",
 	"macsec_include_sci",
 	"macsec_replay_protect",

--- a/wpa_supplicant/wpas_kay.c
+++ b/wpa_supplicant/wpas_kay.c
@@ -243,6 +243,7 @@ int ieee802_1x_alloc_kay_sm(struct wpa_supplicant *wpa_s, struct wpa_ssid *ssid)
                                   ssid->macsec_ciphersuite, ssid->macsec_conf_offset,
                                   ssid->macsec_include_sci,
 				  ssid->macsec_replay_protect, ssid->macsec_replay_window,
+				  ssid->macsec_rekey_period,
 				  ssid->macsec_port, ssid->mka_priority, wpa_s->ifname,
 				  wpa_s->own_addr);
 	/* ieee802_1x_kay_init() frees kay_ctx on failure */

--- a/wpa_supplicant/wpas_kay.c
+++ b/wpa_supplicant/wpas_kay.c
@@ -243,7 +243,7 @@ int ieee802_1x_alloc_kay_sm(struct wpa_supplicant *wpa_s, struct wpa_ssid *ssid)
                                   ssid->macsec_ciphersuite, ssid->macsec_conf_offset,
                                   ssid->macsec_include_sci,
 				  ssid->macsec_replay_protect, ssid->macsec_replay_window,
-				  ssid->macsec_rekey_period,
+				  ssid->mka_rekey_period,
 				  ssid->macsec_port, ssid->mka_priority, wpa_s->ifname,
 				  wpa_s->own_addr);
 	/* ieee802_1x_kay_init() frees kay_ctx on failure */


### PR DESCRIPTION
Add a new configuration instruction `macsec_rekey_period` to indicate the period of proactively refresh SAK.
e.g. `macsec_rekey_period=1800`, which means the macsec SA will be refreshed proactively every 1800 seconds.

Signed-off-by: Ze Gan <ganze718@gmail.com>