### PR TITLE
Increase select timeout

### DIFF
--- a/src/drivers/sonic_operators.cpp
+++ b/src/drivers/sonic_operators.cpp
@@ -18,7 +18,7 @@
 #include <chrono>
 
 // select() function timeout retry time, in millisecond
-constexpr int SELECT_TIMEOUT = 2000;
+constexpr int SELECT_TIMEOUT = 10000;
 
 // Retry times to counter db
 constexpr unsigned int RETRY_TIMES = 20;


### PR DESCRIPTION
We found that the time needed for enabling macsec may be longer than the old timeout, which make the operation failed unexpectedly.