### PR TITLE
Disable P2P module due to vulnerability

### DIFF
--- a/debian/config/wpasupplicant/linux
+++ b/debian/config/wpasupplicant/linux
@@ -501,7 +501,7 @@ CONFIG_AP=y
 # P2P (Wi-Fi Direct)
 # This can be used to enable P2P support in wpa_supplicant. See README-P2P for
 # more information on P2P operations.
-CONFIG_P2P=y
+# CONFIG_P2P=y
 
 # Enable TDLS support
 CONFIG_TDLS=y
@@ -509,7 +509,7 @@ CONFIG_TDLS=y
 # Wi-Fi Display
 # This can be used to enable Wi-Fi Display extensions for P2P using an external
 # program to control the additional information exchanges in the messages.
-CONFIG_WIFI_DISPLAY=y
+# CONFIG_WIFI_DISPLAY=y
 
 # Autoscan
 # This can be used to enable automatic scan support in wpa_supplicant.


### PR DESCRIPTION
Due to P2P module has vulnerability and it wasn't used in SONiC project, disable it.

* CVE-2021-27803

A vulnerability was discovered in how p2p/p2p_pd.c in wpa_supplicant before 2.10 processes P2P (Wi-Fi Direct) provision discovery requests. It could result in denial of service or other impact (potentially execution of arbitrary code), for an attacker within radio range.

* CVE-2021-0326

In p2p_copy_client_info of p2p.c, there is a possible out of bounds write due to a missing bounds check. This could lead to remote code execution if the target device is performing a Wi-Fi Direct search, with no additional execution privileges needed. User interaction is not needed for exploitation.Product: AndroidVersions: Android-10 Android-11 Android-8.1 Android-9Android ID: A-172937525

Signed-off-by: Ze Gan <ganze718@gmail.com>