### PR TITLE
[Rekey] Support for configurable max SAs per Secure Channel

### DIFF
--- a/src/common/ieee802_1x_defs.h
+++ b/src/common/ieee802_1x_defs.h
@@ -72,6 +72,20 @@ enum validate_frames {
 	Strict,
 };
 
+/*
+ * IEEE Association Number (which identifies the SA within an SC
+ * in a Macsec frame) is 2b wide. Hence we can have up to 4
+ * SAs active at any given time per SC. This setting
+ * allows an implementation to specify a lower value
+ */
+enum max_sa_per_sc {
+	MAX_SA_PER_SC_1 = 1,
+	MAX_SA_PER_SC_2 = 2,
+	MAX_SA_PER_SC_3 = 3,
+	MAX_SA_PER_SC_4 = 4,
+	MAX_SA_PER_SC_DEFAULT = MAX_SA_PER_SC_4,
+};
+
 /* IEEE Std 802.1X-2010 - Table 11-6 - Confidentiality Offset */
 enum confidentiality_offset {
 	CONFIDENTIALITY_NONE      = 0,
@@ -81,6 +95,8 @@ enum confidentiality_offset {
 };
 
 /* IEEE Std 802.1X-2010 - Table 9-2 */
+
+#define DEFAULT_PRIO_HIGHEST           0x0
 #define DEFAULT_PRIO_INFRA_PORT        0x10
 #define DEFAULT_PRIO_PRIMRAY_AP        0x30
 #define DEFAULT_PRIO_SECONDARY_AP      0x50

--- a/src/drivers/driver.h
+++ b/src/drivers/driver.h
@@ -4021,6 +4021,14 @@ struct wpa_driver_ops {
 	 */
 	int (*macsec_get_capability)(void *priv, enum macsec_cap *cap);
 
+	 /**
+	 * macsec_get_max_sa_per_sec - Inform MKA of max number of SAs per SC
+	 * @priv: Private driver interface data
+	 * @max: Max number of SAs per SC
+	 * Returns: 0 on success, -1 on failure
+	 */
+	int (*macsec_get_max_sa_per_sc)(void *priv, enum max_sa_per_sc *max);
+
 	/**
 	 * enable_protect_frames - Set protect frames status
 	 * @priv: Private driver interface data

--- a/src/drivers/sonic_operators.cpp
+++ b/src/drivers/sonic_operators.cpp
@@ -250,8 +250,9 @@ public:
             memcpy(name, result[i].first.data(), result[i].first.length() + 1);
             pairs->pairs[pairs->pair_count].name = name;
             char * value = reinterpret_cast<char *>(malloc(result[i].second.length() + 1));
-            memcpy(value, result[i].first.data(), result[i].second.length() + 1);
+            memcpy(value, result[i].second.data(), result[i].second.length() + 1);
             pairs->pairs[pairs->pair_count].value = value;
+            pairs->pair_count++;
         }
         return SONIC_DB_SUCCESS;
     }

--- a/src/pae/ieee802_1x_kay.h
+++ b/src/pae/ieee802_1x_kay.h
@@ -146,6 +146,7 @@ struct ieee802_1x_kay_ctx {
 	/* abstract wpa driver interface */
 	int (*macsec_init)(void *ctx, struct macsec_init_params *params);
 	int (*macsec_deinit)(void *ctx);
+	int (*macsec_get_max_sa_per_sc)(void *priv, enum max_sa_per_sc *max);
 	int (*macsec_get_capability)(void *priv, enum macsec_cap *cap);
 	int (*enable_protect_frames)(void *ctx, bool enabled);
 	int (*enable_encrypt)(void *ctx, bool enabled);
@@ -193,6 +194,7 @@ struct ieee802_1x_kay {
 	bool macsec_include_sci;
 	bool macsec_replay_protect;
 	u32 macsec_replay_window;
+	u8 max_sa_per_sc;
 	enum validate_frames macsec_validate;
 	enum confidentiality_offset macsec_confidentiality;
 	u32 mka_hello_time;

--- a/src/pae/ieee802_1x_secy_ops.c
+++ b/src/pae/ieee802_1x_secy_ops.c
@@ -537,3 +537,32 @@ int secy_deinit_macsec(struct ieee802_1x_kay *kay)
 
 	return ops->macsec_deinit(ops->ctx);
 }
+
+int secy_get_max_sa_per_sc(struct ieee802_1x_kay *kay, enum max_sa_per_sc *max)
+{
+	struct ieee802_1x_kay_ctx *ops;
+
+	if (!kay) {
+		wpa_printf(MSG_ERROR, "KaY: %s params invalid", __func__);
+		return -1;
+	}
+
+	ops = kay->ctx;
+	if (!ops) {
+		wpa_printf(MSG_ERROR,
+			   "KaY: secy get_max_sas_per_sc operation not supported");
+		return -1;
+	}
+
+	/*
+	* If the max SAs per SC setting control is not implemented by
+	* the driver, then return the default
+	*/
+	if( !ops->macsec_get_max_sa_per_sc) {
+		*max = MAX_SA_PER_SC_DEFAULT;
+		return 0;
+	}
+
+	return ops->macsec_get_max_sa_per_sc(ops->ctx, max);
+}
+

--- a/src/pae/ieee802_1x_secy_ops.h
+++ b/src/pae/ieee802_1x_secy_ops.h
@@ -16,6 +16,7 @@ struct ieee802_1x_kay_conf;
 
 int secy_init_macsec(struct ieee802_1x_kay *kay);
 int secy_deinit_macsec(struct ieee802_1x_kay *kay);
+int secy_get_max_sa_per_sc(struct ieee802_1x_kay *kay, enum max_sa_per_sc *max);
 
 /****** CP -> SecY ******/
 int secy_cp_control_validate_frames(struct ieee802_1x_kay *kay,

--- a/wpa_supplicant/driver_i.h
+++ b/wpa_supplicant/driver_i.h
@@ -769,6 +769,14 @@ static inline int wpa_drv_macsec_deinit(struct wpa_supplicant *wpa_s)
 	return wpa_s->driver->macsec_deinit(wpa_s->drv_priv);
 }
 
+static inline int wpa_drv_macsec_get_max_sa_per_sc(struct wpa_supplicant *wpa_s,
+                                            enum max_sa_per_sc *max)
+{
+	if (!wpa_s->driver->macsec_get_max_sa_per_sc)
+		return -1;
+	return wpa_s->driver->macsec_get_max_sa_per_sc(wpa_s->drv_priv, max);
+}
+
 static inline int wpa_drv_macsec_get_capability(struct wpa_supplicant *wpa_s,
 						enum macsec_cap *cap)
 {

--- a/wpa_supplicant/wpas_kay.c
+++ b/wpa_supplicant/wpas_kay.c
@@ -37,6 +37,10 @@ static int wpas_macsec_deinit(void *priv)
 	return wpa_drv_macsec_deinit(priv);
 }
 
+static int wpas_macsec_get_max_sa_per_sc(void *priv, enum max_sa_per_sc *max)
+{
+	return wpa_drv_macsec_get_max_sa_per_sc(priv, max);
+}
 
 static int wpas_macsec_get_capability(void *priv, enum macsec_cap *cap)
 {
@@ -216,6 +220,7 @@ int ieee802_1x_alloc_kay_sm(struct wpa_supplicant *wpa_s, struct wpa_ssid *ssid)
 
 	kay_ctx->macsec_init = wpas_macsec_init;
 	kay_ctx->macsec_deinit = wpas_macsec_deinit;
+	kay_ctx->macsec_get_max_sa_per_sc = wpas_macsec_get_max_sa_per_sc;
 	kay_ctx->macsec_get_capability = wpas_macsec_get_capability;
 	kay_ctx->enable_protect_frames = wpas_enable_protect_frames;
 	kay_ctx->enable_encrypt = wpas_enable_encrypt;


### PR DESCRIPTION
Adding code to query MACSEC_PORT_TABLE max_sa_per_sc in STATE_DB.
In PR https://github.com/Azure/sonic-swss/pull/2250 MacsecOrch will publish the max_sa_per_sc in STATE_DB.
If we don't find the max_sa_per_sc we will default to 4 for max sa per sc.

Max sa per sc is used to determine which AN values can be used during rekey.
If a non-default max sa per sc is specified we will use the max value for rekey server priority.

Infra fix in sonic_operators.cpp.
-`get` function was extracting `value` incorrectly.
-`pair_count` wasn't getting incremented per pair.

Signed-off-by: Nathan Wolfe <nwolfe@arista.com>