### PR TITLE
Remove default cipher from macsec_init

### DIFF
--- a/src/drivers/driver_macsec_sonic.c
+++ b/src/drivers/driver_macsec_sonic.c
@@ -155,7 +155,6 @@ static int macsec_sonic_macsec_init(void *priv, struct macsec_init_params *param
     const struct sonic_db_name_value_pair pairs[] = 
     {
         {"enable", "false"},
-        {"cipher_suite" , "GCM-AES-128"}, // Default cipher suite
         {"send_sci", params->always_include_sci ? "true" : "false"},
     };
     int ret = sonic_db_set(


### PR DESCRIPTION
Cipher was set through macsec_sonic_macsec_init, but also through macsec_sonic_set_current_cipher_suite. The change here is to avoid that occasionally the value from the former is being used in the SAI API calls.