### PR TITLE
[macsec_linux]: Fix compatibility of macsec_get_max_sa_per_sc to macsec linux

### DIFF
--- a/wpa_supplicant/driver_i.h
+++ b/wpa_supplicant/driver_i.h
@@ -772,8 +772,14 @@ static inline int wpa_drv_macsec_deinit(struct wpa_supplicant *wpa_s)
 static inline int wpa_drv_macsec_get_max_sa_per_sc(struct wpa_supplicant *wpa_s,
                                             enum max_sa_per_sc *max)
 {
-	if (!wpa_s->driver->macsec_get_max_sa_per_sc)
-		return -1;
+	/*
+	* If the max SAs per SC setting control is not implemented by
+	* the driver, then return the default
+	*/
+	if(!wpa_s->driver->macsec_get_max_sa_per_sc) {
+		*max = MAX_SA_PER_SC_DEFAULT;
+		return 0;
+	}
 	return wpa_s->driver->macsec_get_max_sa_per_sc(wpa_s->drv_priv, max);
 }
 


### PR DESCRIPTION
Signed-off-by: Ze Gan <ganze718@gmail.com>

To enable MACsec Linux driver, but `macsec_get_max_sa_per_sc` isn't implemented to linux driver so that the MKA session cannot been created.
https://github.com/Azure/sonic-wpa-supplicant/blob/447e9f708df996b8de88ce4fe703c0901357e12b/src/pae/ieee802_1x_kay.c#L3662-L3665

The hierarchy is `secy_get_max_sa_per_sc`->`wpa_drv_macsec_get_max_sa_per_sc`->`wpa_driver_ops::macsec_get_max_sa_per_sc`