### PR TITLE
[driver_macsec_sonic]: Fixing missing zeros at the beginning of SCI

### DIFF
--- a/src/drivers/driver_macsec_sonic.c
+++ b/src/drivers/driver_macsec_sonic.c
@@ -63,14 +63,14 @@ static char * create_buffer(const char * fmt, ...)
 #define CREATE_SC_KEY(IFNAME, SC, SEPARATOR)    \
     create_buffer(                              \
         "%s"                                    \
-        SEPARATOR "%" PRIx64 "",                \
+        SEPARATOR "%016" PRIx64 "",                \
         IFNAME,                                 \
         be_to_host64(mka_sci_u64(&SC->sci)))
 
 #define CREATE_SA_KEY(IFNAME, SA, SEPARATOR)        \
     create_buffer(                                  \
         "%s"                                        \
-        SEPARATOR "%" PRIx64 ""                     \
+        SEPARATOR "%016" PRIx64 ""                     \
         SEPARATOR "%u",                             \
         IFNAME,                                     \
         be_to_host64(mka_sci_u64(&SA->sc->sci)),    \


### PR DESCRIPTION
If the MAC address is like "00:ee:ee:ee:ee:ee:ee", the zeros at the beginning of MAC address will be dropped.
Signed-off-by: Ze Gan <ganze718@gmail.com>