### PR TITLE
[sonic_operators.cpp]: Increasing select timeout

### DIFF
--- a/src/drivers/sonic_operators.cpp
+++ b/src/drivers/sonic_operators.cpp
@@ -33,7 +33,7 @@ extern "C" {
     "(sonic_operators) : %s " FORMAT"\n",__PRETTY_FUNCTION__,__VA_ARGS__
 
 // select() function timeout retry time, in millisecond
-constexpr int SELECT_TIMEOUT = 10 * 60 * 1000; // 5mins
+constexpr int SELECT_TIMEOUT = 10 * 60 * 1000; // 10mins
 
 // Retry times to counter db
 constexpr unsigned int RETRY_TIMES = 20;

--- a/src/drivers/sonic_operators.cpp
+++ b/src/drivers/sonic_operators.cpp
@@ -33,7 +33,7 @@ extern "C" {
     "(sonic_operators) : %s " FORMAT"\n",__PRETTY_FUNCTION__,__VA_ARGS__
 
 // select() function timeout retry time, in millisecond
-constexpr int SELECT_TIMEOUT = 60000;
+constexpr int SELECT_TIMEOUT = 5 * 60 * 1000; // 5mins
 
 // Retry times to counter db
 constexpr unsigned int RETRY_TIMES = 20;

--- a/src/drivers/sonic_operators.cpp
+++ b/src/drivers/sonic_operators.cpp
@@ -33,7 +33,7 @@ extern "C" {
     "(sonic_operators) : %s " FORMAT"\n",__PRETTY_FUNCTION__,__VA_ARGS__
 
 // select() function timeout retry time, in millisecond
-constexpr int SELECT_TIMEOUT = 10000;
+constexpr int SELECT_TIMEOUT = 60000;
 
 // Retry times to counter db
 constexpr unsigned int RETRY_TIMES = 20;

--- a/src/drivers/sonic_operators.cpp
+++ b/src/drivers/sonic_operators.cpp
@@ -33,7 +33,7 @@ extern "C" {
     "(sonic_operators) : %s " FORMAT"\n",__PRETTY_FUNCTION__,__VA_ARGS__
 
 // select() function timeout retry time, in millisecond
-constexpr int SELECT_TIMEOUT = 5 * 60 * 1000; // 5mins
+constexpr int SELECT_TIMEOUT = 10 * 60 * 1000; // 5mins
 
 // Retry times to counter db
 constexpr unsigned int RETRY_TIMES = 20;


### PR DESCRIPTION
According to syslog, the first MACsec events may be processed by orchagent after 5mins in config reload stage. So, increasing the select timeout avoids the exiting of mka state machine.