### PR TITLE
[mka]: Fix rekey of PN based cannot triggered in XPN cipher

### DIFF
--- a/src/pae/ieee802_1x_kay.c
+++ b/src/pae/ieee802_1x_kay.c
@@ -1304,12 +1304,12 @@ ieee802_1x_mka_get_sak_use_length(
 /**
  * ieee802_1x_mka_get_lpn
  */
-static u32
+static u64
 ieee802_1x_mka_get_lpn(struct ieee802_1x_mka_participant *principal,
 		       struct ieee802_1x_mka_ki *ki)
 {
 	struct transmit_sa *txsa;
-	u32 lpn = 0;
+	u64 lpn = 0;
 
 	dl_list_for_each(txsa, &principal->txsc->sa_list,
 			 struct transmit_sa, list) {
@@ -1355,7 +1355,7 @@ ieee802_1x_mka_encode_sak_use_body(
 	struct ieee802_1x_mka_sak_use_body *body;
 	struct ieee802_1x_kay *kay = participant->kay;
 	unsigned int length;
-	u32 olpn, llpn;
+	u64 olpn, llpn;
 
 	length = ieee802_1x_mka_get_sak_use_length(participant);
 	body = wpabuf_put(buf, length);

--- a/src/pae/ieee802_1x_kay.c
+++ b/src/pae/ieee802_1x_kay.c
@@ -1576,7 +1576,8 @@ ieee802_1x_mka_decode_sak_use_body(
 		}
 		if (found) {
 			if (low_bits > lpn) {
-				if (((low_bits + MAX_TOLERANT_PACKET_LOSS) & 0x00000000FFFFFFFFULL) < lpn) {
+				u64 highest_accept_bits = (low_bits + MAX_TOLERANT_PACKET_LOSS) & 0x00000000FFFFFFFFULL;
+				if (low_bits < highest_accept_bits || highest_accept_bits < lpn) {
 					lpn = rxsa->lowest_pn;
 				} else {
 					lpn = (high_bits + (1ULL << 32)) | (lpn & 0x00000000FFFFFFFFULL);

--- a/src/pae/ieee802_1x_kay.c
+++ b/src/pae/ieee802_1x_kay.c
@@ -3388,6 +3388,10 @@ static int ieee802_1x_kay_decode_mkpdu(struct ieee802_1x_kay *kay,
 		if (body_type == MKA_ICV_INDICATOR)
 			return 0;
 
+		// XPN hasn't be supported
+		if (body_type == MKA_XPN)
+			return 0;
+
 		if (left_len < (MKA_HDR_LEN + body_len + DEFAULT_ICV_LEN)) {
 			wpa_printf(MSG_ERROR,
 				   "KaY: MKA Peer Packet Body Length (%zu bytes) is less than the Parameter Set Header Length (%zu bytes) + the Parameter Set Body Length (%zu bytes) + %d bytes of ICV",

--- a/src/pae/ieee802_1x_kay.c
+++ b/src/pae/ieee802_1x_kay.c
@@ -33,6 +33,7 @@
 
 #define PENDING_PN_EXHAUSTION  0x00000000C0000000ULL
 #define PENDING_XPN_EXHAUSTION 0xC000000000000000ULL
+#define MAX_TOLERANT_PACKET_LOSS 0x0000000040000000ULL
 
 #define MKA_ALIGN_LENGTH(len) (((len) + 0x3) & ~0x3)
 
@@ -1459,7 +1460,7 @@ ieee802_1x_mka_decode_sak_use_body(
 	struct data_key *sa_key = NULL;
 	size_t body_len;
 	struct ieee802_1x_mka_ki ki;
-	u32 lpn;
+	u64 lpn;
 	struct ieee802_1x_kay *kay = participant->kay;
 	u32 olpn, llpn;
 
@@ -1552,6 +1553,33 @@ ieee802_1x_mka_decode_sak_use_body(
 			   "KaY: Distributed keys don't match - ignore SAK use");
 		return 0;
 	}
+	if (kay->mka_version == MKA_VERSION_1 && kay->pn_exhaustion == PENDING_XPN_EXHAUSTION) {
+		/* If MKA Verseion is 1 and the cipher is XPN, the highest bits of PN need be recovered from dataplane*/
+		struct receive_sc *rxsc;
+		struct receive_sa *rxsa;
+		u64 high_bits = 0, low_bits = 0;
+		dl_list_for_each(rxsc, &participant->rxsc_list,
+				 struct receive_sc, list) {
+			dl_list_for_each(rxsa, &rxsc->sa_list,
+					 struct receive_sa, list) {
+				if (sa_key && rxsa->pkey == sa_key) {
+					secy_get_receive_lowest_pn(participant->kay, rxsa);
+					high_bits = rxsa->lowest_pn & 0xFFFFFFFF00000000ULL;
+					low_bits = rxsa->lowest_pn & 0x00000000FFFFFFFFULL;
+					break;
+				}
+			}
+		}
+		if (low_bits > lpn) {
+			if (((low_bits + MAX_TOLERANT_PACKET_LOSS) & 0x00000000FFFFFFFFULL) < lpn) {
+				lpn = rxsa->lowest_pn;
+			} else {
+				lpn = (high_bits + (1ULL << 32)) + (lpn & 0xFFFFFFFFULL);
+			}
+		} else {
+			lpn = high_bits + (lpn & 0xFFFFFFFFULL);
+		}
+	}
 	sa_key->next_pn = lpn;
 
 	/* The key server must check that all peers are using the most recent
@@ -1624,7 +1652,7 @@ ieee802_1x_mka_decode_sak_use_body(
 				secy_set_receive_lowest_pn(participant->kay,
 							   rxsa);
 				wpa_printf(MSG_DEBUG,
-					   "KaY: update dist LPN=0x%x", lpn);
+					   "KaY: update dist LPN=%" PRIu64, lpn);
 			}
 		}
 
@@ -3388,9 +3416,10 @@ static int ieee802_1x_kay_decode_mkpdu(struct ieee802_1x_kay *kay,
 		if (body_type == MKA_ICV_INDICATOR)
 			return 0;
 
-		// XPN hasn't be supported
-		if (body_type == MKA_XPN)
-			return 0;
+		if (kay->mka_version == MKA_VERSION_1 && body_type == MKA_XPN) {
+			wpa_printf(MSG_DEBUG, "MKA_XPN (type 8) hasn't been supported in MKA VERSION 1");
+			continue;
+		}
 
 		if (left_len < (MKA_HDR_LEN + body_len + DEFAULT_ICV_LEN)) {
 			wpa_printf(MSG_ERROR,

--- a/src/pae/ieee802_1x_kay_i.h
+++ b/src/pae/ieee802_1x_kay_i.h
@@ -13,7 +13,8 @@
 #include "common/defs.h"
 #include "common/ieee802_1x_defs.h"
 
-#define MKA_VERSION_ID              1
+#define MKA_VERSION_1               1 /* IEEE 802.1X-2010 */
+#define MKA_VERSION_ID              MKA_VERSION_1
 
 /* IEEE Std 802.1X-2010, 11.11.1, Table 11-7 (MKPDU parameter sets) */
 enum mka_packet_type {

--- a/src/pae/ieee802_1x_kay_i.h
+++ b/src/pae/ieee802_1x_kay_i.h
@@ -25,6 +25,7 @@ enum mka_packet_type {
 	MKA_DISTRIBUTED_CAK = 5,
 	MKA_KMD = 6,
 	MKA_ANNOUNCEMENT = 7,
+	MKA_XPN = 8, // Not support
 	MKA_ICV_INDICATOR = 255
 };
 


### PR DESCRIPTION
1. Fix rekey of PN based cannot triggered in XPN cipher due to the wrong type of lpn with u32.
2. Ignore type 8 (MKA_XPN ) of MKA frame 
Signed-off-by: Ze Gan <ganze718@gmail.com>