### PR TITLE
Sync: * OpenSSL: Implement AES keywrap using the EVP API

### DIFF
--- a/src/crypto/crypto_openssl.c
+++ b/src/crypto/crypto_openssl.c
@@ -437,8 +437,52 @@ void aes_decrypt_deinit(void *ctx)
 #ifndef CONFIG_FIPS
 #ifndef CONFIG_OPENSSL_INTERNAL_AES_WRAP
 
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+static const EVP_CIPHER * aes_get_evp_wrap_cipher(size_t keylen)
+{
+	switch (keylen) {
+	case 16:
+		return EVP_aes_128_wrap();
+	case 24:
+		return EVP_aes_192_wrap();
+	case 32:
+		return EVP_aes_256_wrap();
+	default:
+		return NULL;
+	}
+}
+#endif /* OpenSSL version >= 3.0 */
+
+
 int aes_wrap(const u8 *kek, size_t kek_len, int n, const u8 *plain, u8 *cipher)
 {
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+	EVP_CIPHER_CTX *ctx;
+	const EVP_CIPHER *type;
+	int ret = -1, len;
+	u8 buf[16];
+
+	if (TEST_FAIL())
+		return -1;
+
+	type = aes_get_evp_wrap_cipher(kek_len);
+	if (!type)
+		return -1;
+
+	ctx = EVP_CIPHER_CTX_new();
+	if (!ctx)
+		return -1;
+
+	if (EVP_EncryptInit_ex(ctx, type, NULL, kek, NULL) == 1 &&
+	    EVP_CIPHER_CTX_set_padding(ctx, 0) == 1 &&
+	    EVP_EncryptUpdate(ctx, cipher, &len, plain, n * 8) == 1 &&
+	    len == (n + 1) * 8 &&
+	    EVP_EncryptFinal_ex(ctx, buf, &len) == 1)
+		ret = 0;
+
+	EVP_CIPHER_CTX_free(ctx);
+	return ret;
+#else /* OpenSSL version >= 3.0 */
 	AES_KEY actx;
 	int res;
 
@@ -449,12 +493,40 @@ int aes_wrap(const u8 *kek, size_t kek_len, int n, const u8 *plain, u8 *cipher)
 	res = AES_wrap_key(&actx, NULL, cipher, plain, n * 8);
 	OPENSSL_cleanse(&actx, sizeof(actx));
 	return res <= 0 ? -1 : 0;
+#endif /* OpenSSL version >= 3.0 */
 }
 
 
 int aes_unwrap(const u8 *kek, size_t kek_len, int n, const u8 *cipher,
 	       u8 *plain)
 {
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+	EVP_CIPHER_CTX *ctx;
+	const EVP_CIPHER *type;
+	int ret = -1, len;
+	u8 buf[16];
+
+	if (TEST_FAIL())
+		return -1;
+
+	type = aes_get_evp_wrap_cipher(kek_len);
+	if (!type)
+		return -1;
+
+	ctx = EVP_CIPHER_CTX_new();
+	if (!ctx)
+		return -1;
+
+	if (EVP_DecryptInit_ex(ctx, type, NULL, kek, NULL) == 1 &&
+	    EVP_CIPHER_CTX_set_padding(ctx, 0) == 1 &&
+	    EVP_DecryptUpdate(ctx, plain, &len, cipher, (n + 1) * 8) == 1 &&
+	    len == n * 8 &&
+	    EVP_DecryptFinal_ex(ctx, buf, &len) == 1)
+		ret = 0;
+
+	EVP_CIPHER_CTX_free(ctx);
+	return ret;
+#else /* OpenSSL version >= 3.0 */
 	AES_KEY actx;
 	int res;
 
@@ -465,6 +537,7 @@ int aes_unwrap(const u8 *kek, size_t kek_len, int n, const u8 *cipher,
 	res = AES_unwrap_key(&actx, NULL, plain, cipher, (n + 1) * 8);
 	OPENSSL_cleanse(&actx, sizeof(actx));
 	return res <= 0 ? -1 : 0;
+#endif /* OpenSSL version >= 3.0 */
 }
 
 #endif /* CONFIG_OPENSSL_INTERNAL_AES_WRAP */


### PR DESCRIPTION


Why I did it
The below two PRs added some extra compile options to ignore the compiler errors during the Debian bookworm building.
https://github.com/sonic-net/sonic-wpa-supplicant/pull/79
https://github.com/sonic-net/sonic-wpa-supplicant/pull/80

This PR is to gracefully fix these compiler errors and meet the FIPS compliance requirements.



How I did it
Ported the below commit:
https://w1.fi/cgit/hostap/commit/?id=092efd45a6186c72b5a44f98ad99c81fd33402a6

OpenSSL 3.0 deprecated the low-level encryption functions, so use the EVP API for this. Maintain the previous version for BoringSSL and LibreSSL since not all versions seem to have the EVP_aes_*_wrap() functions needed for the EVP API.



How to verify it
In the KVM-based testbed environment, tested it with FIPS and non-FIPS mode by running the SONiC MACSEC testing suite and got PASSED results.

The KVM-based testbed setup manual.
https://github.com/sonic-net/sonic-mgmt/blob/master/docs/testbed/README.testbed.VsSetup.md#option-1-veos-kvm-based-image

~/sonic-mgmt/tests$ ./run_tests.sh -n vms-kvm-t0 -d vlab-01 -c macsec/test_controlplane.py -f vtestbed.yaml -i ../ansible/veos_vtb -u -e "--enable_macsec --neighbor_type=sonic --macsec_profile=128_SCI,256_XPN_SCI" -x

macsec/test_controlplane.py::TestControlPlane::test_wpa_supplicant_processes[128_SCI] PASSED                                                                                                                                                 [ 12%]
macsec/test_controlplane.py::TestControlPlane::test_appl_db[128_SCI] PASSED                                                                                                                                                                  [ 25%]
macsec/test_controlplane.py::TestControlPlane::test_mka_session[128_SCI] PASSED                                                                                                                                                              [ 37%]
macsec/test_controlplane.py::TestControlPlane::test_rekey_by_period[128_SCI] SKIPPED (If the rekey period is 0 which means rekey by period isn't active.)                                                                                    [ 50%]
macsec/test_controlplane.py::TestControlPlane::test_wpa_supplicant_processes[256_XPN_SCI] PASSED                                                                                                                                             [ 62%]
macsec/test_controlplane.py::TestControlPlane::test_appl_db[256_XPN_SCI] PASSED                                                                                                                                                              [ 75%]
macsec/test_controlplane.py::TestControlPlane::test_mka_session[256_XPN_SCI] PASSED                                                                                                                                                          [ 87%]
macsec/test_controlplane.py::TestControlPlane::test_rekey_by_period[256_XPN_SCI] PASSED