### PR TITLE
[driver_macsec_sonic]: Fix MACsec XPN cipher init in SONiC MACsec driver 

### DIFF
--- a/src/drivers/driver.h
+++ b/src/drivers/driver.h
@@ -2330,6 +2330,7 @@ struct macsec_init_params {
 	bool always_include_sci;
 	bool use_es;
 	bool use_scb;
+	u64 cs_id; /* MACsec cipher suite ID (see ieee802_1x_defs.h CS_ID_*). */
 };
 #endif /* CONFIG_MACSEC */
 

--- a/src/pae/ieee802_1x_secy_ops.c
+++ b/src/pae/ieee802_1x_secy_ops.c
@@ -512,6 +512,7 @@ int secy_init_macsec(struct ieee802_1x_kay *kay)
 	params.use_es = false;
 	params.use_scb = false;
 	params.always_include_sci = kay->macsec_include_sci;
+	params.cs_id = kay->macsec_cs_id;
 
 	ret = ops->macsec_init(ops->ctx, &params);
 


### PR DESCRIPTION
## Summary
This PR plumbs additional MACsec context from KaY into the SONiC MACsec driver and corrects the initial cipher suite advertised in MACSEC_PORT_TABLE, preventing a Redis table race that could program XPN SALT/SSCI as zero in hardware.

### Code changes

In `src/drivers/driver.h`:

- Add `u64 cs_id` to `struct macsec_init_params` so the MACsec secy/driver can see which cipher suite KaY selected (e.g. `CS_ID_GCM_AES_XPN_256`).

In `macsec_sonic_macsec_init()`:
- Replace the previous hardcoded `"GCM-AES-128"` default with the mapped `cipher_suite` string derived from `params->cs_id`.
- This ensures the **initial** `MACSEC_PORT_TABLE:<port>.cipher_suite` row reflects the actual configured profile (including XPN ciphers), not always `GCM-AES-128`.

## Motivation / Background

This change is driven by the [github issue](https://github.com/sonic-net/sonic-wpa-supplicant/issues/104) **"MACsec XPN SALT/SSCI / cipher-suite ordering issue " ** for a dataplane failure seen on hardware :

- The MACsec profile on both DUT and SONiC VM peer was configured for **XPN** (`GCM-AES-XPN-256`).
- CONFIG_DB and APPL_DB on both sides correctly showed non-zero **SALT** and **SSCI** for the XPN SAs.
- However, on the hardware DUT, ASIC_DB showed some MACsec SAs programmed with:
  - `SAI_MACSEC_SA_ATTR_SALT`  = all zeros
  - `SAI_MACSEC_SA_ATTR_MACSEC_SSCI` = `0`
 
- At the same time, `show macsec` reported:
  - `cipher_suite           GCM-AES-XPN-256`
- And non-zero SALT/SSCI values for the same SA in the higher-level
MACsec CLI view.

The net effect was:

- The peer rejected all packets as `IN_PKTS_NOT_VALID` because the two ends derived different nonces/ICVs.
- LACP over MACsec never came up on the hardware DUT, even though MACsec appeared to be "up" from a control-plane perspective and `show macsec` showed the expected XPN profile and SALT/SSCI.

### Reproduction
This issue can be reproduced by running the sonic-mgmt MACsec dataplane tests (e.g. tests/macsec/test_dataplane.py) in a loop on DUT; after some iterations, the DUT ends up with XPN SAs in ASIC_DB that have SALT=0 / SSCI=0 while CONFIG_DB/APPL_DB still show GCM-AES-XPN-256, and the peer rejects all traffic

### Root cause (driver side)

The RCA identified a control-plane/event-ordering issue between `wpa_supplicant` (KaY), the SONiC MACsec driver, and `macsecorch`:

1. KaY selects an XPN cipher suite (e.g. `GCM-AES-XPN-256`) and stores it as `kay->macsec_cs_id`.
2. When `secy_init_macsec(kay)` calls `ops->macsec_init(ctx, &params)`, the `macsec_init_params` struct **did not previously carry** this cipher suite ID.
3. The SONiC MACsec driver (`driver_macsec_sonic`) implemented `macsec_init` by **always** writing an initial port row:
- `MACSEC_PORT_TABLE:<port> = { enable = false, cipher_suite = "GCM-AES-128", ... }`.
4. `macsecorch` subscribes to `MACSEC_PORT_TABLE` and initializes each port's internal `m_cipher_suite` from that first row, defaulting to AES-128 if nothing else is present.
5. When MKA finishes and SAs are pushed into APPL_DB **for XPN**, KaY programs SALT/SSCI correctly in the SA rows. However, because the driver never told SONiC about the real XPN cipher suite at `macsec_init` time, `macsecorch` may still be tracking the port as non-XPN (based on the earlier `GCM-AES-128` initialization) when it first processes those SA rows.
6. In that case, `macsecorch` treats the SAs as non-XPN and, by design, **skips SALT/SSCI handling for non-XPN** cipher suites. It therefore creates SAs in ASIC with:
   - Correct SAK
   - SALT = 0, SSCI = 0
- XPN-related SAI attributes such as `SAI_MACSEC_SA_ATTR_CONFIGURED_EGRESS_XPN = 1`, but without the correct SALT/SSCI programmed.
7. Once these SAs are created in ASIC with SALT/SSCI zeroed, later reconciliation of the cipher suite string or profile in higher layers (so that `show macsec` displays XPN and non-zero SALT/SSCI) **does not retroactively fix the already-programmed SAs** on the hardware DUT.

By making `macsec_init_params` carry the cipher suite ID and using that to set the **initial** `MACSEC_PORT_TABLE.cipher_suite`, this PR fixes the "AES-128 default at init" issue on the driver side. As a result:

- From the moment MACsec is initialized, `MACSEC_PORT_TABLE.cipher_suite` reflects the actual profile cipher (including XPN ciphers).
- `macsecorch` no longer starts from a stale non-XPN view for ports that are really XPN-only, greatly reducing the chance that it will create XPN SAs in ASIC with SALT/SSCI zeroed.

### Why the issue is intermittent?

Below are three key events for a port:

- A. macsec_init() writes MACSEC_PORT_TABLE.cipher_suite = GCM-AES-128.
- B. set_current_cipher_suite(XPN) makes the driver write cipher_suite = GCM-AES-XPN-128.
- C. MKA completes and MACSEC_*_SA_TABLE entries appear (with XPN SAK/SALT/SSCI).
   
On orchagent’s side, what matters is the order in which it sees and processes A/B/C.

“Good” ordering (no failure) -> If orchagent processes B → C:

1. It first sees B, updates MACSEC_PORT_TABLE.cipher_suite to XPN, and sets m_cipher_suite = XPN.
2. When C (SA rows) arrive, it already believes the port is XPN: • Parses SALT/SSCI. • Programs SAs with correct non‑zero SALT/SSCI and XPN flags. • Creates SCs initially with XPN cipher.

“Bad” ordering (intermittent failure) -> If orchagent processes C while still on A, i.e. C → B:
 1. A made it think the port is non‑XPN (AES‑128).
 2. C arrives (SA rows) while m_cipher_suite is still non‑XPN: • It skips SALT/SSCI because it thinks they are not applicable. • Creates SAs with SALT = 0, SSCI = 0. These are permanently wrong. • Creates SCs originally as AES‑128 for that SCI.

 3. Later B flips the APPL_DB cipher to XPN: • macsecorch issues SET SAI_MACSEC_SC_ATTR_MACSEC_CIPHER_SUITE = XPN on the existing SC.
• On this SAI, that SET is effectively a no‑op → ASIC_DB still shows AES‑128.
• Even if SC cipher changed, SAs are already wrong and cannot be fixed, because SALT/SSCI are CREATE_ONLY.
This is the failure we saw: SAs with SALT/SSCI 0 and peer reporting IN_PKTS_NOT_VALID.

Because the relative ordering A/B/C is influenced by control‑plane timing, MKA, redis digestion, etc., we only sometimes hit C → B. Since there is sonic db wait used for set_current_cipher_suite(cs_id) –(which writes PORT row with cipher=GCM-AES-XPN-*), macsecorch can end up processing the tables in wrong order. That’s why the error is intermittent.

## Testing
Ran sonic-mgmt macsec dataplane test multiple times with this fix and tests passed always

Which release branch to backport?
[x] 202511


