### PR TITLE
Fix GCC 14 build error: add hostapd_deinit_driver declaration

### DIFF
--- a/src/ap/hostapd.h
+++ b/src/ap/hostapd.h
@@ -679,4 +679,10 @@ void fst_hostapd_fill_iface_obj(struct hostapd_data *hapd,
 				struct fst_wpa_obj *iface_obj);
 #endif /* CONFIG_FST */
 
+#ifdef CONFIG_SONIC_HOSTAPD
+void hostapd_deinit_driver(const struct wpa_driver_ops *driver,
+			   void *drv_priv,
+			   struct hostapd_iface *hapd_iface);
+#endif /* CONFIG_SONIC_HOSTAPD */
+
 #endif /* HOSTAPD_H */


### PR DESCRIPTION
## Description
Fix build failure with GCC 14 (Debian trixie) where implicit function declarations are treated as errors.

Fixes #113

## Root Cause
`hostapd_deinit_driver()` is defined in `src/ap/hostapd.c` (non-static under `CONFIG_SONIC_HOSTAPD`) but has no prototype in any header. GCC 14 errors on this:
```
main.c:404:9: error: implicit declaration of function 'hostapd_deinit_driver'
```

## Changes
- `src/ap/hostapd.h`: Add function prototype under `#ifdef CONFIG_SONIC_HOSTAPD`

## Testing
- Verified the function signature matches the definition in hostapd.c
- This is a header-only change adding a missing declaration

## Impact
Blocks the docker-macsec trixie upgrade tracked in https://github.com/sonic-net/SONiC/issues/2169