### PR TITLE
azure-pipelines: migrate libyang1 deb install to libyang3

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,8 +54,8 @@ jobs:
       path: $(Build.ArtifactStagingDirectory)/download
       artifact: common-lib
       patterns: |
-        target/debs/bookworm/libyang-*_1.0*.deb
-        target/debs/bookworm/libyang_1.0*.deb
+        target/debs/bookworm/libyang-dev_3*.deb
+        target/debs/bookworm/libyang3_*.deb
     displayName: "Download libyang from amd64 common lib"
   - script: |
       set -ex
@@ -123,8 +123,8 @@ jobs:
       path: $(Build.ArtifactStagingDirectory)/download
       artifact: common-lib.arm64
       patterns: |
-        target/debs/bookworm/libyang-*_1.0*.deb
-        target/debs/bookworm/libyang_1.0*.deb
+        target/debs/bookworm/libyang-dev_3*.deb
+        target/debs/bookworm/libyang3_*.deb
     displayName: "Download libyang from arm64 common lib"
   - script: |
       set -ex
@@ -193,8 +193,8 @@ jobs:
       path: $(Build.ArtifactStagingDirectory)/download
       artifact: common-lib.armhf
       patterns: |
-        target/debs/bookworm/libyang-*_1.0*.deb
-        target/debs/bookworm/libyang_1.0*.deb
+        target/debs/bookworm/libyang-dev_3*.deb
+        target/debs/bookworm/libyang3_*.deb
     displayName: "Download libyang from armhf common lib"
   - script: |
       set -ex


### PR DESCRIPTION
#### Why I did it

sonic-buildimage no longer builds the libyang1 debs (`libyang_1.0.73`, `libyang-cpp`, `python3-yang`) from its `common_libs` pipeline; it now builds only libyang3. The Azure pipeline for this repo downloads `libyang-*_1.0*.deb` and `libyang_1.0*.deb` from the `common-lib` build artifact, which no longer exist. CI therefore fails to fetch the libyang debs and the build breaks.

Part of sonic-net/sonic-buildimage#22385.

#### How I did it

Updated the `DownloadPipelineArtifact@2` filters in all three architecture blocks (amd64, arm64, armhf) in `azure-pipelines.yml` to pull the libyang3 debs from the `common-lib` artifact, using versionless globs (no hardcoded versions):

- `target/debs/bookworm/libyang-*_1.0*.deb` -> `target/debs/bookworm/libyang-dev_*.deb`
- `target/debs/bookworm/libyang_1.0*.deb` -> `target/debs/bookworm/libyang3_*.deb`

The install steps already use a versionless `sudo dpkg -i $(find ./download -name *.deb)`, so no change was required there.

The plain Debian `apt-get install libyang-dev` in `.github/workflows/codeql-analysis.yml` is not sourced from sonic-buildimage artifacts and was intentionally left unchanged.

#### How to verify it

Run the Azure pipeline. The "Download libyang from ... common lib" steps should successfully fetch `libyang3_*.deb` and `libyang-dev_*.deb` from the `common-lib` artifact, the "Install libyang from common lib" steps should install them, and the wpa supplicant build should complete.

#### Description for the changelog

azure-pipelines: migrate libyang1 deb download to libyang3
