### PR TITLE
MACsec MKA: log and count MKPDUs dropped for unknown CKN

### DIFF
--- a/src/pae/ieee802_1x_kay.c
+++ b/src/pae/ieee802_1x_kay.c
@@ -3324,7 +3324,23 @@ static int ieee802_1x_kay_mkpdu_sanity_check(struct ieee802_1x_kay *kay,
 	/* CKN should be owned by I */
 	participant = ieee802_1x_kay_get_participant(kay, body->ckn, ckn_len);
 	if (!participant) {
-		wpa_printf(MSG_DEBUG, "KaY: CKN is not included in my CA");
+		time_t now = time(NULL);
+
+		kay->mkpdu_unknown_ckn++;
+		/*
+		 * A corrupted or foreign CKN repeats on every MKPDU (~2 s), so
+		 * rate-limit the log to once per minute per port; the first
+		 * drop is always logged. Raised from MSG_DEBUG so a silent,
+		 * one-directional MACsec teardown is visible at the deployed
+		 * log level. The running count is exported via wpa_cli STATUS.
+		 */
+		if (kay->mkpdu_unknown_ckn_last_log == 0 ||
+		    now - kay->mkpdu_unknown_ckn_last_log >= 60) {
+			wpa_printf(MSG_WARNING,
+				   "KaY: CKN is not included in my CA - dropping MKPDU on %s (unknown-CKN drops: %" PRIu64 ")",
+				   kay->if_name, kay->mkpdu_unknown_ckn);
+			kay->mkpdu_unknown_ckn_last_log = now;
+		}
 		return -1;
 	}
 
@@ -4191,7 +4207,8 @@ int ieee802_1x_kay_get_status(struct ieee802_1x_kay *kay, char *buf,
 			  "Is Key Server=%s\n"
 			  "Number of Keys Distributed=%u\n"
 			  "Number of Keys Received=%u\n"
-			  "MKA Hello Time=%u\n",
+			  "MKA Hello Time=%u\n"
+			  "MKPDU Unknown CKN Drops=%" PRIu64 "\n",
 			  kay->active ? "Active" : "Not-Active",
 			  kay->authenticated ? "Yes" : "No",
 			  kay->secured ? "Yes" : "No",
@@ -4201,7 +4218,8 @@ int ieee802_1x_kay_get_status(struct ieee802_1x_kay *kay, char *buf,
 			  kay->is_key_server ? "Yes" : "No",
 			  kay->dist_kn - 1,
 			  kay->rcvd_keys,
-			  kay->mka_hello_time);
+			  kay->mka_hello_time,
+			  kay->mkpdu_unknown_ckn);
 	if (os_snprintf_error(end - pos, res))
 		return 0;
 	pos += res;

--- a/src/pae/ieee802_1x_kay.h
+++ b/src/pae/ieee802_1x_kay.h
@@ -243,6 +243,11 @@ struct ieee802_1x_kay {
 
 	enum validate_frames vf;
 	enum confidentiality_offset co;
+
+	/* RX MKPDUs dropped because the CKN matched no local CA, counted per
+	 * port and exposed via the KaY status (wpa_cli STATUS). */
+	u64 mkpdu_unknown_ckn;
+	time_t mkpdu_unknown_ckn_last_log;
 };
 
 


### PR DESCRIPTION
Fixes #118

#### Why I did it

When MKA receives an MKPDU whose CKN matches no local CA, `ieee802_1x_kay_mkpdu_sanity_check()` dropped the frame at `MSG_DEBUG` with no counter (`src/pae/ieee802_1x_kay.c`). The drop happens *before* ICV verification, so there is no ICV error either. At a typical deployed log level this is invisible: a single-byte CKN corruption (on the wire or in memory) causes a silent, one-directional MACsec teardown and permanent rekey failure with no operator-visible signal. Triage requires raising `wpa_supplicant` to `DEBUG` on a live, already-impaired port.

The adjacent CKN-length check already logs at `MSG_WARNING`; the more operationally significant CKN-not-in-CA case logged at `MSG_DEBUG`.

#### How I did it

- Raise the drop to `MSG_WARNING` (consistent with the adjacent CKN-length check), rate-limited to once per minute per port — MKPDUs arrive roughly every 2 s, so a repeating bad CKN would otherwise flood the log; the first drop is always logged.
- Add a per-port counter `mkpdu_unknown_ckn` to `struct ieee802_1x_kay` (zero-initialised via the existing allocation), incremented on every such drop regardless of log throttling.
- Surface the counter via the KaY status (`wpa_cli STATUS`) as `MKPDU Unknown CKN Drops`, so the condition is detectable without raising the live log level to `DEBUG`.

#### How to verify it

On a MACsec link with MKA established (matching CKN on both ends), corrupt the CKN on one end so it no longer matches the peer, then restart MKA on that port:

- `syslog` shows, at WARNING, rate-limited (once per minute per port):
  `KaY: CKN is not included in my CA - dropping MKPDU on <ifname> (unknown-CKN drops: N)`
- `wpa_cli -i <ifname> status` shows a growing `MKPDU Unknown CKN Drops=N`.
- With a matching CKN, the counter stays `0` and no WARNING is emitted.

Verified on hardware with a SONiC MACsec peer: 45 drops produced 2 WARNING lines (60 s apart), the `STATUS` counter tracked all 45, and restoring the correct CKN froze the counter and recovered the session.

#### Description for the changelog

MACsec MKA: log (rate-limited WARNING) and count MKPDUs dropped for an unknown CKN, exposed via `wpa_cli STATUS`.
