### PR TITLE
debian/rules: upgrade FORTIFY_SOURCE to level 3

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,12 +1,14 @@
 #!/usr/bin/make -f
 
 export QT_SELECT=qt5
-export DEB_BUILD_MAINT_OPTIONS = hardening=+all
-# Upgrade FORTIFY_SOURCE to level 3 (dpkg default is =2).
+# hardening=+all,-fortify: enable all hardening flags except dpkg's built-in
+# fortify (which injects -D_FORTIFY_SOURCE=2). We inject level 3 ourselves below.
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all,-fortify
+# Upgrade FORTIFY_SOURCE to level 3.
 # FORTIFY_SOURCE requires -O1 or higher; skip the override for noopt builds.
 ifeq (,$(filter noopt,$(DEB_BUILD_OPTIONS)))
-export DEB_CPPFLAGS_MAINT_APPEND = -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3
-FORTIFY3_FLAGS := -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3
+export DEB_CPPFLAGS_MAINT_APPEND = -D_FORTIFY_SOURCE=3
+FORTIFY3_FLAGS := -D_FORTIFY_SOURCE=3
 else
 FORTIFY3_FLAGS :=
 endif
@@ -19,15 +21,15 @@ include /usr/share/dpkg/default.mk
 # to resolve the compile errors with bookworm. There are deprecated APIs with
 # openssl 3.0 which are used by wpa supplicant. We can remove those flags when
 # there are solutions ready.
-DEB_CFLAGS_MAINT_APPEND   = -MMD -Wall $(shell dpkg-buildflags --get CPPFLAGS) $(FORTIFY3_FLAGS) -Wno-error=array-bounds $(warning WARNING: Building with -Wno-error=array-bounds) \
+DEB_CFLAGS_MAINT_APPEND   = -MMD -Wall $(CPPFLAGS) $(FORTIFY3_FLAGS) -Wno-error=array-bounds $(warning WARNING: Building with -Wno-error=array-bounds) \
                                       -Wno-deprecated-declarations $(warning WARNING: Building with -Wno-deprecated-declarations) \
                                       -Wno-use-after-free $(warning WARNING: Building with -Wno-use-after-free)       \
                                       -Wno-discarded-qualifiers $(warning WARNING: Building with -Wno-discarded-qualifiers)
-DEB_CXXFLAGS_MAINT_APPEND = $(shell dpkg-buildflags --get CPPFLAGS) $(FORTIFY3_FLAGS)
+DEB_CXXFLAGS_MAINT_APPEND = $(CPPFLAGS) $(FORTIFY3_FLAGS)
 DEB_LDFLAGS_MAINT_APPEND  = -Wl,--as-needed
 export DEB_CFLAGS_MAINT_APPEND DEB_CXXFLAGS_MAINT_APPEND DEB_LDFLAGS_MAINT_APPEND
 
-UCFLAGS   = -MMD -Wall -fPIC $(shell dpkg-buildflags --get CPPFLAGS) $(shell dpkg-buildflags --get CFLAGS) $(FORTIFY3_FLAGS)
+UCFLAGS   = -MMD -Wall -fPIC $(CPPFLAGS) $(CFLAGS) $(FORTIFY3_FLAGS)
 
 BINDIR    = /sbin
 V = 1

--- a/debian/rules
+++ b/debian/rules
@@ -1,9 +1,15 @@
 #!/usr/bin/make -f
 
 export QT_SELECT=qt5
-# Upgrade FORTIFY_SOURCE to level 3 (dpkg default is =2).
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+# Upgrade FORTIFY_SOURCE to level 3 (dpkg default is =2).
+# FORTIFY_SOURCE requires -O1 or higher; skip the override for noopt builds.
+ifeq (,$(filter noopt,$(DEB_BUILD_OPTIONS)))
 export DEB_CPPFLAGS_MAINT_APPEND = -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3
+FORTIFY3_FLAGS := -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3
+else
+FORTIFY3_FLAGS :=
+endif
 DPKG_EXPORT_BUILDFLAGS = 1
 include /usr/share/dpkg/default.mk
 
@@ -13,15 +19,15 @@ include /usr/share/dpkg/default.mk
 # to resolve the compile errors with bookworm. There are deprecated APIs with
 # openssl 3.0 which are used by wpa supplicant. We can remove those flags when
 # there are solutions ready.
-DEB_CFLAGS_MAINT_APPEND   = -MMD -Wall $(shell dpkg-buildflags --get CPPFLAGS) -Wno-error=array-bounds $(warning WARNING: Building with -Wno-error=array-bounds) \
+DEB_CFLAGS_MAINT_APPEND   = -MMD -Wall $(shell dpkg-buildflags --get CPPFLAGS) $(FORTIFY3_FLAGS) -Wno-error=array-bounds $(warning WARNING: Building with -Wno-error=array-bounds) \
                                       -Wno-deprecated-declarations $(warning WARNING: Building with -Wno-deprecated-declarations) \
                                       -Wno-use-after-free $(warning WARNING: Building with -Wno-use-after-free)       \
                                       -Wno-discarded-qualifiers $(warning WARNING: Building with -Wno-discarded-qualifiers)
-DEB_CXXFLAGS_MAINT_APPEND = $(shell dpkg-buildflags --get CPPFLAGS)
+DEB_CXXFLAGS_MAINT_APPEND = $(shell dpkg-buildflags --get CPPFLAGS) $(FORTIFY3_FLAGS)
 DEB_LDFLAGS_MAINT_APPEND  = -Wl,--as-needed
 export DEB_CFLAGS_MAINT_APPEND DEB_CXXFLAGS_MAINT_APPEND DEB_LDFLAGS_MAINT_APPEND
 
-UCFLAGS   = -MMD -Wall -fPIC $(shell dpkg-buildflags --get CPPFLAGS) $(shell dpkg-buildflags --get CFLAGS)
+UCFLAGS   = -MMD -Wall -fPIC $(shell dpkg-buildflags --get CPPFLAGS) $(shell dpkg-buildflags --get CFLAGS) $(FORTIFY3_FLAGS)
 
 BINDIR    = /sbin
 V = 1

--- a/debian/rules
+++ b/debian/rules
@@ -1,7 +1,9 @@
 #!/usr/bin/make -f
 
 export QT_SELECT=qt5
-export DEB_BUILD_MAINT_OPTIONS=hardening=+all
+# Upgrade FORTIFY_SOURCE to level 3 (dpkg default is =2).
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+export DEB_CPPFLAGS_MAINT_APPEND = -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3
 DPKG_EXPORT_BUILDFLAGS = 1
 include /usr/share/dpkg/default.mk
 


### PR DESCRIPTION
#### Why I did it

Upgrade `_FORTIFY_SOURCE` from the dpkg default of 2 to 3 to strengthen buffer overflow detection in shipped binaries.

##### Work item tracking

- Microsoft ADO:

#### How I did it

- Add `ifeq (,$(filter noopt,$(DEB_BUILD_OPTIONS)))` guard: skip the level-3 override when `noopt` is set, since `FORTIFY_SOURCE` requires at least `-O1` and dpkg disables it for unoptimized builds
- Set `FORTIFY3_FLAGS := -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3` and append explicitly to `DEB_CFLAGS_MAINT_APPEND`, `DEB_CXXFLAGS_MAINT_APPEND`, and `UCFLAGS` so the flag reaches all build paths including the udeb, not just CPPFLAGS consumers
- Keep `DEB_CPPFLAGS_MAINT_APPEND` for the dpkg-controlled path

#### How to verify it

CI build passes. Verify flag is active:
```
dpkg-buildpackage -us -uc 2>&1 | grep -o 'FORTIFY_SOURCE=[0-9]' | sort -u
```
Expected output: `FORTIFY_SOURCE=3` only.

#### Description for the changelog

upgrade FORTIFY_SOURCE to level 3

#### Link to config_db schema for YANG changes

N/A